### PR TITLE
Fix typo in tiddlywiki.files

### DIFF
--- a/files/tiddlywiki.files
+++ b/files/tiddlywiki.files
@@ -1,7 +1,7 @@
 {
 	"tiddlers": [
 		{
-			"file": "TexZilla-min.js",
+			"file": "TeXZilla-min.js",
 			"fields": {
 				"type": "application/javascript",
 				"title": "$:/plugins/joerenes/TW5-TeXZilla/TeXZilla-min.js",


### PR DESCRIPTION
The typo was causing an error when building TiddlyWiki, as it contained
a reference to an inexistent file.
